### PR TITLE
Remove quotes from hspec_match result

### DIFF
--- a/lua/neotest-haskell/base.lua
+++ b/lua/neotest-haskell/base.lua
@@ -225,7 +225,7 @@ end
 -- @return the hspec match for the test (see example).
 -- @type string
 function M.get_hspec_match(position)
-  return '"/' .. get_hspec_match(position) .. '/"'
+  return '/' .. get_hspec_match(position) .. '/'
 end
 
 return M


### PR DESCRIPTION
* The quotes caused cabal to not find any tests