### PR TITLE
fix: detect files ending in "Tests.hs" as test files

### DIFF
--- a/lua/neotest-haskell/base.lua
+++ b/lua/neotest-haskell/base.lua
@@ -8,6 +8,7 @@ M.is_test_file = function(file_path)
   end
   return vim.endswith(file_path, "Spec.hs")
       or vim.endswith(file_path, "Test.hs")
+      or vim.endswith(file_path, "Tests.hs")
 end
 
 M.filter_dir = function(name)


### PR DESCRIPTION
Love the plugin! I've been using it to run through the Haskell trac on Exercism but annoyingly they call their test files "Tests.hs" which means this plugin doesn't detect them. So I've expanded the test file detection conditional to pick those up to