### PR TITLE
fix: trim parsed test fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Trims string ends from failed test results
 
 ## [0.2.1] - 2022-10-29
 ### Fixed

--- a/lua/neotest-haskell/hspec.lua
+++ b/lua/neotest-haskell/hspec.lua
@@ -247,7 +247,7 @@ local function get_hspec_errors(raw_lines, test_name)
         message = error_message,
       } }
     elseif pos_found then
-      error_message = error_message and error_message .. '\n' .. trimmed or trimmed
+      error_message = error_message and error_message:gsub('%s*$', '') .. '\n' .. trimmed or trimmed
     end
     if failures_found and trimmed:match('.*' .. util.escape(test_name) .. '.*') then
       pos_found = true

--- a/lua/neotest-haskell/hspec.lua
+++ b/lua/neotest-haskell/hspec.lua
@@ -241,13 +241,13 @@ local function get_hspec_errors(raw_lines, test_name)
   local pos_found = false
   local error_message = nil
   for _, line in ipairs(raw_lines) do
-    local trimmed = line:match('^%s*(.*)'):gsub('%s*$', '')
+    local trimmed = (line:match('^%s*(.*)') or line):gsub('%s*$', '')
     if pos_found and trimmed:match('To rerun use:') then
       return { {
         message = error_message,
       } }
     elseif pos_found then
-      error_message = error_message and error_message:gsub('%s*$', '') .. '\n' .. trimmed or trimmed
+      error_message = error_message and error_message .. '\n' .. trimmed or trimmed
     end
     if failures_found and trimmed:match('.*' .. util.escape(test_name) .. '.*') then
       pos_found = true


### PR DESCRIPTION
###### Description of changes
### Image preview done with the following commands:
> tested using repo repo https://github.com/Trouble-Truffle/tablefmt
> with commit ID `a6765c2530acf55ea91c10a6c4bc173a9c34b3ac`
> cloned to dir `~/.local/src/tablefmt`
```
nix develop
NVIM_DATA_MINIMAL=$(mktemp -d) nvim -u ./tests/minimal.lua
:cd ~/.local/src/tablefmt
:e ./test/Tests.hs
:lua require'neotest'.setup({adapters = {require('neotest-haskell')}})`
:lua require("neotest").run.run(vim.fn.expand("%"))
#I've no idea why you have to repeat these two lines twice in this order
:lua require'neotest'.setup({adapters = {require('neotest-haskell')}})`
:lua require("neotest").run.run(vim.fn.expand("%"))
```
![image](https://user-images.githubusercontent.com/90542764/210997841-74aa709c-5931-473d-b9dd-c09f719ae037.png)

On personal config:
![image](https://user-images.githubusercontent.com/90542764/210990080-6fad147a-3eb1-4932-a6a3-c96ddf744122.png)

------
the PR removes the `^M`'s
![image](https://user-images.githubusercontent.com/90542764/210996172-87a74d38-8dff-4b33-ac62-f37e68790ca3.png)
![image](https://user-images.githubusercontent.com/90542764/210998012-18fded6d-ddff-4273-a25a-4a9b42e264b9.png)

###### Things done

- [x] Tested, as applicable:
  - [ ] Added plenary specs
  - [x] Manually
- [ ] Updated [CHANGELOG.md](../CHANGELOG.md) (if applicable).
- [x] Fits [CONTRIBUTING.md](https://github.com/MrcJkb/neotest-haskell/blob/master/CONTRIBUTING.md)
