### PR TITLE
fix(tree-sitter): allow test nodes to be detected as root nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Don't pass `-p` option to `tasty` if no paths to filter on are detected.
+- Tree-sitter root node detection in test files for which namespaces
+  cannot be detected: Allow `test` nodes to be root nodes, too.
 ### Changed
 - Treat all files with `spec` or `test` in the path as test files.
 

--- a/lua/neotest-haskell/position.lua
+++ b/lua/neotest-haskell/position.lua
@@ -47,15 +47,13 @@ function position.mk_top_level_node_parser(prepend_result, concat_results)
     local prepended = {}
     for _, node in pos:iter_nodes() do
       local data = node:data()
-      if data.type == 'namespace' then
-        local parent = node:parent()
-        local parent_data = parent and parent:data()
-        local is_top_level = not parent_data or parent_data.type ~= 'namespace'
-        local is_new = not vim.tbl_contains(prepended, data.name)
-        if is_top_level and is_new then
-          table.insert(prepended, data.name)
-          results = prepend_result(results, data.name)
-        end
+      local parent = node:parent()
+      local parent_data = parent and parent:data()
+      local is_top_level = not parent_data or parent_data.type == 'file'
+      local is_new = not vim.tbl_contains(prepended, data.name)
+      if is_top_level and is_new then
+        table.insert(prepended, data.name)
+        results = prepend_result(results, data.name)
       end
     end
     return concat_results(results)


### PR DESCRIPTION
Fixes root node detection if no namespaces are detected.