### PR TITLE
fix: typo in tasty module

### DIFF
--- a/lua/neotest-haskell/tasty.lua
+++ b/lua/neotest-haskell/tasty.lua
@@ -99,7 +99,7 @@ end
 
 ---@param pos neotest.Tree The position.
 ---@return string[] test_opts The Stack test options for matching a tasty filter.
-function hspec.get_stack_test_opts(pos)
+function tasty.get_stack_test_opts(pos)
   local pattern = mk_tasty_pattern(pos)
   return pattern and {
     '--ta',


### PR DESCRIPTION
I noticed this while trying to run neotest haskell in a stack project with tasty tests. Once I fixed this typo, I was able to do things like `lua require('neotest').run.run()` and have the test run. Without this change, it would fail with an error saying `Cannot run tests for configured build tools: stack`.